### PR TITLE
Allow passing opts in NewSessionOpts, add --debug flag to demo.

### DIFF
--- a/cmd/cimc/main.go
+++ b/cmd/cimc/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anuvu/axepect/pkg/cimc"
 	"github.com/anuvu/axepect/pkg/loginshell"
 	"github.com/apex/log"
+	goexpect "github.com/google/goexpect"
 	"github.com/urfave/cli/v2"
 )
 
@@ -28,6 +29,11 @@ func main() {
 					&cli.StringFlag{
 						Name:  "serial-login",
 						Usage: "Attempt serial login over SOL with user:pass",
+					},
+					&cli.BoolFlag{
+						Name:  "debug",
+						Usage: "enable debug output",
+						Value: false,
 					},
 				},
 			},
@@ -54,7 +60,12 @@ func demoMain(c *cli.Context) error {
 
 	loginCreds := c.String("serial-login")
 
-	cs, err := cimc.NewSession(host+":22", user, pass)
+	opts := []goexpect.Option{}
+	if c.Bool("debug") {
+		opts = append(opts, goexpect.Verbose(true), goexpect.VerboseWriter(os.Stderr))
+	}
+
+	cs, err := cimc.NewSessionOpts(host+":22", user, pass, opts)
 	if err != nil {
 		log.Fatalf("failed new session: %v", err)
 	}

--- a/pkg/cimc/api_test.go
+++ b/pkg/cimc/api_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/anuvu/axepect/pkg/cimc"
 	"github.com/anuvu/axepect/pkg/test"
+	goexpect "github.com/google/goexpect"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -27,7 +28,9 @@ func TestAPIs(t *testing.T) {
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	ctx := context.TODO()
 	Convey("Given a CIMC session", t, func() {
-		sess, err := cimc.NewSession(addr, "test", "test123")
+		sess, err := cimc.NewSessionOpts(addr, "test", "test123",
+			[]goexpect.Option{goexpect.Verbose(true), goexpect.VerboseWriter(os.Stderr)})
+
 		So(sess, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 		Convey("GetPowerState()", func() {

--- a/pkg/cimc/cimc.go
+++ b/pkg/cimc/cimc.go
@@ -3,7 +3,6 @@ package cimc
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -32,6 +31,14 @@ type Session struct {
 // NewSession - return a Session, logging in with password and user@addr
 //   For example NewSession("10.0.0.1", "admin", "password")
 func NewSession(addr, user, pass string) (CIMCSession, error) {
+	return NewSessionOpts(addr, user, pass, []goexpect.Option{})
+}
+
+// NewSessionOpts - return a Session, with provided goexpect.Option list
+//   For example to enable debug:
+//     NewSessionOpts("10.0.0.1", "admin", "password",
+//        []goexpect.Option{goexpect.Verbose(true), goexpect.VerboseWriter(os.Stderr)})
+func NewSessionOpts(addr, user, pass string, opts []goexpect.Option) (CIMCSession, error) {
 	sess := &Session{}
 	fmt.Printf("Connecting to %s@%s\n", user, addr)
 	sshClt, err := ssh.Dial("tcp", addr, &ssh.ClientConfig{
@@ -55,9 +62,6 @@ func NewSession(addr, user, pass string) (CIMCSession, error) {
 	tios.Wz.WsCol, tios.Wz.WsRow = 0, 32768
 	tios.Lflag |= term.ECHO
 
-	opts := []goexpect.Option{}
-	// To debug, just add options
-	opts = []goexpect.Option{goexpect.Verbose(true), goexpect.VerboseWriter(os.Stderr)}
 	e, _, err := goexpect.SpawnSSHPTY(sshClt, timeout, tios, opts...)
 	if err != nil {
 		return sess, err


### PR DESCRIPTION
A previous commit turned on debug in the demo program, which is very loud.
This adds a '--debug' flag and implements the same functionality by
adding and calling a NewSessionOpts method that takes an []Option.