### PR TITLE
When sending commands, confirm yes we really meant that.

### DIFF
--- a/pkg/cimc/cimc.go
+++ b/pkg/cimc/cimc.go
@@ -2,6 +2,7 @@ package cimc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -170,6 +171,12 @@ func (cs *Session) SendCmd(ctx context.Context, msg string) (string, error) {
 		dataLines = append(dataLines, line)
 	}
 	response := strings.Join(dataLines, "\n")
+	if len(dataLines) > 0 {
+		lastLine := dataLines[len(dataLines)-1]
+		if strings.HasPrefix("Error:", lastLine) {
+			return response + "\n", errors.New(lastLine)
+		}
+	}
 
 	return response + "\n", nil
 }

--- a/pkg/cimc/cimc.go
+++ b/pkg/cimc/cimc.go
@@ -104,11 +104,12 @@ func (cs *Session) Close(ctx context.Context) error {
 // SendCmd - send a command to the cimc command line interface.  Return its response.
 func (cs *Session) SendCmd(ctx context.Context, msg string) (string, error) {
 	fields := strings.Fields(msg)
+	cmd := fields[0]
 	if strings.HasPrefix(msg, "/") {
 		toks := strings.Split(fields[0], "/")
 
 		// support SendCmd("/bios/memory/show detail")
-		cmd := toks[len(toks)-1]
+		cmd = toks[len(toks)-1]
 		scope := strings.Join(toks[1:len(toks)-1], "/")
 
 		_, err := cs.SendCmd(ctx, "top")
@@ -133,7 +134,7 @@ func (cs *Session) SendCmd(ctx context.Context, msg string) (string, error) {
 		send = msg
 	} else {
 		for _, n := range noMoreCmds {
-			if fields[0] == n {
+			if cmd == n {
 				send = msg
 				break
 			}


### PR DESCRIPTION
3 changes here:

 * Look for 'Error' in SendCmd response and return error.
 * Recognize 'no-more' commands even when sent with full path.
 * Respond with 'y' if SendCmd results in a confirmation prompt.