### PR TITLE
Fix PowerCycle to turn on if system is already off.

### DIFF
--- a/pkg/cimc/api.go
+++ b/pkg/cimc/api.go
@@ -23,7 +23,7 @@ type CIMCSession interface {
 	PowerOn(context.Context) error
 	// PowerOff powers off the connected host
 	PowerOff(context.Context) error
-	// PowerCycle powers off and then on the connected host
+	// PowerCycle powers off (if on) and then on the connected host
 	PowerCycle(context.Context) error
 	// GetPowerState gets the power state of the connected host
 	GetPowerState(context.Context) (PowerState, error)

--- a/pkg/cimc/power.go
+++ b/pkg/cimc/power.go
@@ -37,7 +37,16 @@ func (cs *Session) PowerOn(ctx context.Context) error {
 
 // PowerCycle - Turn power off, if off and then back on.
 func (cs *Session) PowerCycle(ctx context.Context) error {
-	return powerCmd(ctx, cs, "cycle")
+	curState, err := cs.GetPowerState(ctx)
+	if err != nil {
+		return err
+	}
+	operation := "cycle"
+	if curState == Off {
+		// system was off, turn it on.
+		operation = "on"
+	}
+	return powerCmd(ctx, cs, operation)
 }
 
 func powerCmd(ctx context.Context, cs *Session, cmd string) error {


### PR DESCRIPTION
If you send 'power cycle' to a cimc where the system is currently
off, it will do nothing.

This fixes PowerCycle to do what the user wanted...
 * if the system is off, turn it on.
 * if the system is on, power cycle.